### PR TITLE
Install current nodejs to prevent SyntaxError in yarn/lib/cli.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y apt-transport-https
 RUN curl -sS 'https://dl.yarnpkg.com/debian/pubkey.gpg' | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN curl -sS 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key' | apt-key add - && \
+  echo "deb https://deb.nodesource.com/node_12.x stretch main" | tee /etc/apt/sources.list.d/nodesource.list
+
 RUN apt-get update && apt-get install -y yarn nodejs cmake
 
 # Install ruby libraries


### PR DESCRIPTION
I tried to start development on the exercise website (for https://github.com/exercism/exercism/issues/4865) on macOS, but didn't get this to run. This fixes the above-mentioned error by installing a never nodejs version https://github.com/nodesource/distributions/blob/d66f5c249f1eea424f1e86092276ce758d7ca7f3/deb/setup_12.x referenced on https://github.com/nodesource/distributions/blob/a135801ac44274281ac52fd9051c252297eccfc2/README.md#installation-instructions