### PR TITLE
Use docker-compose's default name (directory)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 
 IMG_PREFIX=unused
-PROJECT=exercism
 
 all: website website/server_identity run
 
@@ -17,21 +16,21 @@ push:
 	docker push $(IMG_PREFIX)/$(PROJECT)_rails
 
 init:
-	docker-compose -p $(PROJECT) exec rails bin/rails exercism:setup
+	docker-compose exec rails bin/rails exercism:setup
 
 migrate:
-	docker-compose -p $(PROJECT) exec rails bin/rails db:migrate
+	docker-compose exec rails bin/rails db:migrate
 
 run:
-	docker-compose -p $(PROJECT) up
+	docker-compose up
 
 bash:
-	docker-compose -p $(PROJECT) exec rails bash
+	docker-compose exec rails bash
 
 test:
-	docker-compose -p $(PROJECT) exec rails bin/rails test
+	docker-compose exec rails bin/rails test
 
 clean:
-	docker-compose -p $(PROJECT) down && docker rmi $(PROJECT)_rails
+	docker-compose down && docker rmi $(PROJECT)_rails
 
 .PHONY: all setup build init run test clean

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ troubles please feel free to open an issue.
 
 ```
 $ echo "host" > server_identity # Set server identity file
-$ docker-compose -p exercism up # Start the local development environment
-$ docker-compose -p exercism exec rails bin/rails exercism:setup # Setup database and git repos
+$ docker-compose up # Start the local development environment
+$ docker-compose exec rails bin/rails exercism:setup # Setup database and git repos
 
-$ docker-compose -p exercism down # Remove local environment
+$ docker-compose down # Remove local environment
 $ docker rmi exercism_rails # Cleanup build docker image
 ```
 


### PR DESCRIPTION
Does the `-p exercism` / `$(PROJECT)` result from the fact that you renamed this repo's directory locally? Since your `git clone` instructions don't use another repos name, the `PROJECT=exercism` may introduce an incompatibility risk, doesn't it? How about removing all this and letting Docker use the repo's name?

Alternative: Maybe introducing `git clone … exercism.io` or `exercism-web-app` in the [`README.md`](https://github.com/unused/exercism-docker/compare/master...katrinleinweber:patch-2?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R9) would be an unambigous way to name the local dev directory?