### PR TITLE
Update bundler in Dockerfile before installing gems.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN curl -sS 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key' | apt-key ad
 RUN apt-get update && apt-get install -y yarn nodejs cmake
 
 # Install ruby libraries
+RUN gem update bundler
 RUN bundle install
 
 # Install JavaScript libraries


### PR DESCRIPTION
When building the image, it will crash with "You must use Bundler 2 or greater with this lockfile." Updating bundler before installing the gems fixes this.