### PR TITLE
Bind rails to 0.0.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ RUN bundle exec rake bin/setup
 EXPOSE 3000
 
 # Run the development server
-CMD ["bin/rails", "server"]
+CMD ["bin/rails", "server", "--binding=0.0.0.0"]


### PR DESCRIPTION
Rails (in development) will bind to localhost:3000 inside the container. However, when you publish this port, rails won't be able to accept request because it's no longer localhost. Listening to 0.0.0.0 instead fixes this.